### PR TITLE
Make the image name and type as variables, to be taken as input from …

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,22 @@ Type: `bool`
 
 Default: `true`
 
+### <a name="input_http_proxy"></a> [http\_proxy](#input\_http\_proxy)
+
+Description: HTTP URLs for proxy server. An example URL is:http://proxy.example.com:3128.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_https_proxy"></a> [https\_proxy](#input\_https\_proxy)
+
+Description: HTTPS URLs for proxy server. The server may still use an HTTP address as shown in this example: http://proxy.example.com:3128.
+
+Type: `string`
+
+Default: `null`
+
 ### <a name="input_lock"></a> [lock](#input\_lock)
 
 Description: Controls the Resource Lock configuration for this resource. The following properties can be specified:
@@ -226,6 +242,14 @@ Type: `number`
 
 Default: `8192`
 
+### <a name="input_no_proxy"></a> [no\_proxy](#input\_no\_proxy)
+
+Description: URLs, which can bypass proxy. Typical examples would be [localhost,127.0.0.1,.svc,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,100.0.0.0/8]
+
+Type: `list(string)`
+
+Default: `[]`
+
 ### <a name="input_private_ip_address"></a> [private\_ip\_address](#input\_private\_ip\_address)
 
 Description: The private IP address of the NIC
@@ -269,6 +293,14 @@ Default: `{}`
 Description: (Optional) Tags of the resource.
 
 Type: `map(string)`
+
+Default: `null`
+
+### <a name="input_trusted_ca"></a> [trusted\_ca](#input\_trusted\_ca)
+
+Description: Name of the certificate file path for your proxy server.
+
+Type: `string`
 
 Default: `null`
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Default: `true`
 
 ### <a name="input_http_proxy"></a> [http\_proxy](#input\_http\_proxy)
 
-Description: HTTP URLs for proxy server. An example URL is:http://proxy.example.com:3128.
+Description: HTTP URL for proxy server. An example URL is:http://proxy.example.com:3128.
 
 Type: `string`
 
@@ -192,7 +192,7 @@ Default: `null`
 
 ### <a name="input_https_proxy"></a> [https\_proxy](#input\_https\_proxy)
 
-Description: HTTPS URLs for proxy server. The server may still use an HTTP address as shown in this example: http://proxy.example.com:3128.
+Description: HTTPS URL for proxy server. The server may still use an HTTP address as shown in this example: http://proxy.example.com:3128.
 
 Type: `string`
 
@@ -298,7 +298,7 @@ Default: `null`
 
 ### <a name="input_trusted_ca"></a> [trusted\_ca](#input\_trusted\_ca)
 
-Description: Name of the certificate file path for your proxy server.
+Description: Alternative CA cert to use for connecting to proxy servers.
 
 Type: `string`
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -37,9 +37,9 @@ data "azapi_resource" "customlocation" {
   parent_id = data.azurerm_resource_group.rg.id
 }
 
-data "azapi_resource" "win_server_image" {
-  type      = "Microsoft.AzureStackHCI/marketplaceGalleryImages@2023-09-01-preview"
-  name      = "winServer2022-01"
+data "azapi_resource" "vm_image" {
+  type      = var.is_marketplace_image ? "Microsoft.AzureStackHCI/marketplaceGalleryImages@2023-09-01-preview" : "Microsoft.AzureStackHCI/galleryImages@2023-09-01-preview"
+  name      = var.image_name
   parent_id = data.azurerm_resource_group.rg.id
 }
 
@@ -63,7 +63,7 @@ module "test" {
   location              = data.azurerm_resource_group.rg.location
   custom_location_id    = data.azapi_resource.customlocation.id
   name                  = var.name
-  image_id              = data.azapi_resource.win_server_image.id
+  image_id              = data.azapi_resource.vm_image.id
   logical_network_id    = data.azapi_resource.logical_network.id
   admin_username        = var.vm_admin_username
   admin_password        = var.vm_admin_password
@@ -99,7 +99,7 @@ The following resources are used by this module:
 
 - [azapi_resource.customlocation](https://registry.terraform.io/providers/azure/azapi/latest/docs/data-sources/resource) (data source)
 - [azapi_resource.logical_network](https://registry.terraform.io/providers/azure/azapi/latest/docs/data-sources/resource) (data source)
-- [azapi_resource.win_server_image](https://registry.terraform.io/providers/azure/azapi/latest/docs/data-sources/resource) (data source)
+- [azapi_resource.vm_image](https://registry.terraform.io/providers/azure/azapi/latest/docs/data-sources/resource) (data source)
 - [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) (data source)
 
 <!-- markdownlint-disable MD013 -->

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -79,6 +79,17 @@ module "test" {
   domain_target_ou      = var.domain_target_ou
   domain_join_user_name = var.domain_join_user_name
   domain_join_password  = var.domain_join_password
+
+
+  # # Optional block to configure a proxy server for your VM
+  # http_proxy = "http://username:password@proxyserver.contoso.com:3128"
+  # https_proxy = "https://username:password@proxyserver.contoso.com:3128"
+  # no_proxy = [
+  #     "localhost",
+  #     "127.0.0.1"
+  # ]
+  # trusted_ca = "C:\\Users\\Palomino\\proxycert.crt"
+
 }
 ```
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -109,19 +109,19 @@ The following input variables are required:
 
 ### <a name="input_custom_location_name"></a> [custom\_location\_name](#input\_custom\_location\_name)
 
-Description: The name of the custom location.
+Description: Enter the custom location name of your HCI cluster.
 
 Type: `string`
 
 ### <a name="input_image_name"></a> [image\_name](#input\_image\_name)
 
-Description: The name of the image
+Description: Enter the name of the image you would like to use for the VM deployment
 
 Type: `string`
 
 ### <a name="input_logical_network_name"></a> [logical\_network\_name](#input\_logical\_network\_name)
 
-Description: The name of the logical network
+Description: Enter the name of the logical network you would like to use for the VM deployment
 
 Type: `string`
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -113,6 +113,12 @@ Description: The name of the custom location.
 
 Type: `string`
 
+### <a name="input_image_name"></a> [image\_name](#input\_image\_name)
+
+Description: The name of the image
+
+Type: `string`
+
 ### <a name="input_logical_network_name"></a> [logical\_network\_name](#input\_logical\_network\_name)
 
 Description: The name of the logical network
@@ -226,6 +232,14 @@ Default: `512`
 Description: This variable controls whether or not telemetry is enabled for the module.  
 For more information see <https://aka.ms/avm/telemetryinfo>.  
 If it is set to false, then no telemetry will be collected.
+
+Type: `bool`
+
+Default: `true`
+
+### <a name="input_is_marketplace_image"></a> [is\_marketplace\_image](#input\_is\_marketplace\_image)
+
+Description: Set to true if the referenced image is from Azure Marketplace.
 
 Type: `bool`
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -88,7 +88,7 @@ module "test" {
   #     "localhost",
   #     "127.0.0.1"
   # ]
-  # trusted_ca = "C:\\Users\\Palomino\\proxycert.crt"
+  # trusted_ca = "-----BEGIN CERTIFICATE-----....-----END CERTIFICATE-----"
 
 }
 ```

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -82,6 +82,6 @@ module "test" {
   #     "localhost",
   #     "127.0.0.1"
   # ]
-  # trusted_ca = "C:\\Users\\Palomino\\proxycert.crt"
+  # trusted_ca = "-----BEGIN CERTIFICATE-----....-----END CERTIFICATE-----"
 
 }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -73,4 +73,15 @@ module "test" {
   domain_target_ou      = var.domain_target_ou
   domain_join_user_name = var.domain_join_user_name
   domain_join_password  = var.domain_join_password
+
+
+  # # Optional block to configure a proxy server for your VM
+  # http_proxy = "http://username:password@proxyserver.contoso.com:3128"
+  # https_proxy = "https://username:password@proxyserver.contoso.com:3128"
+  # no_proxy = [
+  #     "localhost",
+  #     "127.0.0.1"
+  # ]
+  # trusted_ca = "C:\\Users\\Palomino\\proxycert.crt"
+
 }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -31,9 +31,9 @@ data "azapi_resource" "customlocation" {
   parent_id = data.azurerm_resource_group.rg.id
 }
 
-data "azapi_resource" "win_server_image" {
-  type      = "Microsoft.AzureStackHCI/marketplaceGalleryImages@2023-09-01-preview"
-  name      = "winServer2022-01"
+data "azapi_resource" "vm_image" {
+  type      = var.is_marketplace_image ? "Microsoft.AzureStackHCI/marketplaceGalleryImages@2023-09-01-preview" : "Microsoft.AzureStackHCI/galleryImages@2023-09-01-preview"
+  name      = var.image_name
   parent_id = data.azurerm_resource_group.rg.id
 }
 
@@ -57,7 +57,7 @@ module "test" {
   location              = data.azurerm_resource_group.rg.location
   custom_location_id    = data.azapi_resource.customlocation.id
   name                  = var.name
-  image_id              = data.azapi_resource.win_server_image.id
+  image_id              = data.azapi_resource.vm_image.id
   logical_network_id    = data.azapi_resource.logical_network.id
   admin_username        = var.vm_admin_username
   admin_password        = var.vm_admin_password

--- a/examples/default/variables.tf
+++ b/examples/default/variables.tf
@@ -15,7 +15,7 @@ variable "is_marketplace_image" {
 }
 
 variable "image_name" {
-  type = string
+  type        = string
   description = "The name of the image"
 }
 

--- a/examples/default/variables.tf
+++ b/examples/default/variables.tf
@@ -3,20 +3,14 @@ variable "custom_location_name" {
   description = "The name of the custom location."
 }
 
-variable "logical_network_name" {
-  type        = string
-  description = "The name of the logical network"
-}
-
-variable "is_marketplace_image" {
-  type        = bool
-  default     = true
-  description = "Set to true if the referenced image is from Azure Marketplace."
-}
-
 variable "image_name" {
   type        = string
   description = "The name of the image"
+}
+
+variable "logical_network_name" {
+  type        = string
+  description = "The name of the logical network"
 }
 
 variable "name" {
@@ -115,6 +109,12 @@ This variable controls whether or not telemetry is enabled for the module.
 For more information see <https://aka.ms/avm/telemetryinfo>.
 If it is set to false, then no telemetry will be collected.
 DESCRIPTION
+}
+
+variable "is_marketplace_image" {
+  type        = bool
+  default     = true
+  description = "Set to true if the referenced image is from Azure Marketplace."
 }
 
 variable "memory_mb" {

--- a/examples/default/variables.tf
+++ b/examples/default/variables.tf
@@ -1,16 +1,16 @@
 variable "custom_location_name" {
   type        = string
-  description = "The name of the custom location."
+  description = "Enter the custom location name of your HCI cluster."
 }
 
 variable "image_name" {
   type        = string
-  description = "The name of the image"
+  description = "Enter the name of the image you would like to use for the VM deployment"
 }
 
 variable "logical_network_name" {
   type        = string
-  description = "The name of the logical network"
+  description = "Enter the name of the logical network you would like to use for the VM deployment"
 }
 
 variable "name" {

--- a/examples/default/variables.tf
+++ b/examples/default/variables.tf
@@ -8,6 +8,17 @@ variable "logical_network_name" {
   description = "The name of the logical network"
 }
 
+variable "is_marketplace_image" {
+  type        = bool
+  default     = true
+  description = "Set to true if the referenced image is from Azure Marketplace."
+}
+
+variable "image_name" {
+  type = string
+  description = "The name of the image"
+}
+
 variable "name" {
   type        = string
   description = "Name of the VM resource"

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,12 @@ resource "azapi_resource" "virtual_machine" {
           targetMemoryBuffer = var.dynamic_memory_buffer
         }
       }
+      httpProxyConfig = var.http_proxy == null && var.https_proxy == null ? null : {
+        httpProxy  = var.http_proxy
+        httpsProxy = var.https_proxy
+        noProxy    = var.no_proxy
+        trustedCa  = var.trusted_ca
+      }
       osProfile = {
         adminUsername = var.admin_username
         adminPassword = var.admin_password

--- a/variables.tf
+++ b/variables.tf
@@ -134,6 +134,20 @@ DESCRIPTION
   nullable    = false
 }
 
+variable "http_proxy" {
+  type        = string
+  default     = null
+  description = "HTTP URLs for proxy server. An example URL is:http://proxy.example.com:3128."
+  sensitive   = true
+}
+
+variable "https_proxy" {
+  type        = string
+  default     = null
+  description = "HTTPS URLs for proxy server. The server may still use an HTTP address as shown in this example: http://proxy.example.com:3128."
+  sensitive   = true
+}
+
 variable "lock" {
   type = object({
     kind = string
@@ -175,6 +189,12 @@ variable "memory_mb" {
   description = "Memory in MB"
 }
 
+variable "no_proxy" {
+  type        = list(string)
+  default     = []
+  description = "URLs, which can bypass proxy. Typical examples would be [localhost,127.0.0.1,.svc,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,100.0.0.0/8]"
+}
+
 variable "private_ip_address" {
   type        = string
   default     = ""
@@ -213,6 +233,12 @@ variable "tags" {
   type        = map(string)
   default     = null
   description = "(Optional) Tags of the resource."
+}
+
+variable "trusted_ca" {
+  type        = string
+  default     = null
+  description = "Name of the certificate file path for your proxy server."
 }
 
 variable "user_storage_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -137,14 +137,14 @@ DESCRIPTION
 variable "http_proxy" {
   type        = string
   default     = null
-  description = "HTTP URLs for proxy server. An example URL is:http://proxy.example.com:3128."
+  description = "HTTP URL for proxy server. An example URL is:http://proxy.example.com:3128."
   sensitive   = true
 }
 
 variable "https_proxy" {
   type        = string
   default     = null
-  description = "HTTPS URLs for proxy server. The server may still use an HTTP address as shown in this example: http://proxy.example.com:3128."
+  description = "HTTPS URL for proxy server. The server may still use an HTTP address as shown in this example: http://proxy.example.com:3128."
   sensitive   = true
 }
 
@@ -238,7 +238,7 @@ variable "tags" {
 variable "trusted_ca" {
   type        = string
   default     = null
-  description = "Name of the certificate file path for your proxy server."
+  description = "Alternative CA cert to use for connecting to proxy servers."
 }
 
 variable "user_storage_id" {


### PR DESCRIPTION
…the user

## Description

Updated the default example in the `examples/default` directory.

### Problem
The image name and type are hardcoded in the template, as shown below:
```hcl
data "azapi_resource" "win_server_image" {
  type      = "Microsoft.AzureStackHCI/marketplaceGalleryImages@2023-09-01-preview"
  name      = "winServer2022-01"
  parent_id = data.azurerm_resource_group.rg.id
}
```
### Solution
This PR provides a way to accept the image type and name from the user by adding the following two variables:

1. `is_marketplace_image` [Optional] - Indicates whether the referenced image is from Azure Marketplace. If set to `true`, the type used will be `Microsoft.AzureStackHCI/marketplaceGalleryImages`; otherwise, it will be `Microsoft.AzureStackHCI/galleryImages`. This variable is optional and defaults to `true`.
2. `image_name` - Specifies the name of the image used to create the ARC VM.


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
