### PR TITLE
add variable for custom data and add to os profile

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -13,7 +13,7 @@ locals {
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
   virtual_machine_osProfile = {
     computerName = var.name
-    customData = var.custom_data
+    customData   = var.custom_data
     linuxConfiguration = {
       ssh = var.linux_ssh_config == null ? {} : var.linux_ssh_config
     }

--- a/locals.tf
+++ b/locals.tf
@@ -13,6 +13,7 @@ locals {
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
   virtual_machine_osProfile = {
     computerName = var.name
+    customData = var.custom_data
     linuxConfiguration = {
       ssh = var.linux_ssh_config == null ? {} : var.linux_ssh_config
     }

--- a/variables.tf
+++ b/variables.tf
@@ -289,7 +289,7 @@ variable "security_type" {
   description = "Specifies the SecurityType of the virtual machine. EnableTPM and SecureBootEnabled must be set to true for SecurityType to function.. Possible values are 'TrustedLaunch' and 'ConfidentialVM'."
 
   validation {
-    condition     = var.security_type == null || contains(["TrustedLaunch", "ConfidentialVM"], coalesce(var.security_type, ""))
+    condition     = var.security_type == null || contains(["TrustedLaunch", "ConfidentialVM"], var.security_type)
     error_message = "The security_type must be one of: 'TrustedLaunch', 'ConfidentialVM', or null."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,11 @@ variable "admin_username" {
   }
 }
 
+variable "custom_data" {
+  type        = string
+  description = "The custom data foro the Azure Stack HCI virtual machine. This should be a base64 encoded string."
+}
+
 variable "custom_location_id" {
   type        = string
   description = "The custom location ID for the Azure Stack HCI cluster."

--- a/variables.tf
+++ b/variables.tf
@@ -289,7 +289,7 @@ variable "security_type" {
   description = "Specifies the SecurityType of the virtual machine. EnableTPM and SecureBootEnabled must be set to true for SecurityType to function.. Possible values are 'TrustedLaunch' and 'ConfidentialVM'."
 
   validation {
-    condition     = var.security_type == null || contains(["TrustedLaunch", "ConfidentialVM"], var.security_type)
+    condition     = var.security_type == null || contains(["TrustedLaunch", "ConfidentialVM"], tostring(var.security_type))
     error_message = "The security_type must be one of: 'TrustedLaunch', 'ConfidentialVM', or null."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -289,7 +289,7 @@ variable "security_type" {
   description = "Specifies the SecurityType of the virtual machine. EnableTPM and SecureBootEnabled must be set to true for SecurityType to function.. Possible values are 'TrustedLaunch' and 'ConfidentialVM'."
 
   validation {
-    condition     = var.security_type == null || contains(["TrustedLaunch", "ConfidentialVM"], tostring(var.security_type))
+    condition     = var.security_type == null || contains(["TrustedLaunch", "ConfidentialVM"], coalesce(var.security_type, ""))
     error_message = "The security_type must be one of: 'TrustedLaunch', 'ConfidentialVM', or null."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,7 @@ variable "admin_username" {
 variable "custom_data" {
   type        = string
   description = "The custom data foro the Azure Stack HCI virtual machine. This should be a base64 encoded string."
+  default     = ""
 }
 
 variable "custom_location_id" {


### PR DESCRIPTION
## Description

This PR simply adds a variable to consume custom data then sets that custom data on the os profile for the virtual machine.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [X] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
