### PR TITLE
update to add provisionVMAgent and provisionVMConfigAgent to linux ma…

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -14,6 +14,8 @@ locals {
   virtual_machine_osProfile = {
     computerName = var.name
     linuxConfiguration = {
+      provisionVMAgent = true
+      provisionVMConfigAgent = true
       ssh = var.linux_ssh_config == null ? {} : var.linux_ssh_config
     }
     windowsConfiguration = {


### PR DESCRIPTION
## Description

Adds the provisionVMAgent and proovisionVMConfigAgent to the linux configuration for linux machines.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
